### PR TITLE
Add 'packages' entry to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import sys
-from setuptools import setup
+from setuptools import setup, find_packages
 
 if sys.version < '3':
     raise ImportError(
@@ -9,6 +9,7 @@ if sys.version < '3':
 setup(
     name='autodiff',
     version='0.5',
+    packages=find_packages(),
     maintainer='Lowin Data Company',
     maintainer_email='info@lowindata.com',
     description=('Automatic differentiation for NumPy.'),


### PR DESCRIPTION
Hi there,

I've been trying to try out `pyautodiff` with no luck, as

```
python setup.py install
```

does not copy the package files over to `site_packages`, resulting in errors such as:

```
    from autodiff import gradient
ImportError: No module named 'autodiff'
```

This pull request is to fix that, by adding a `packages` entry in `setuptools`' `setup`.

Cheers
