### PR TITLE
Fix PY3 print() error

### DIFF
--- a/autodiff/fmin_sgd.py
+++ b/autodiff/fmin_sgd.py
@@ -223,7 +223,7 @@ def fmin_sgd(*args, **kwargs):
         t = time.time()
         vals = obj.nextN(print_interval)
         if len(vals):
-            print 'Value', np.mean(vals), 'time', (time.time() - t)
+            print('Value', np.mean(vals), 'time', (time.time() - t))
         else:
             break
     return obj.current_args


### PR DESCRIPTION
This is just a minor fix. After this, I was able to install `pyautodiff` with no errors.

Thanks for developing this package, it seems very interesting.

GV
